### PR TITLE
Add sensors to Yardian integration

### DIFF
--- a/homeassistant/components/yardian/__init__.py
+++ b/homeassistant/components/yardian/__init__.py
@@ -12,7 +12,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import YardianUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -1,0 +1,87 @@
+"""Yardian binary sensor platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+    BinarySensorDeviceClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+@dataclass
+class YardianBinarySensorDescription(BinarySensorEntityDescription):
+    """Describe a Yardian binary sensor."""
+
+    value_fn: Callable[[YardianUpdateCoordinator], bool | None]
+
+
+SENSORS: tuple[YardianBinarySensorDescription, ...] = (
+    YardianBinarySensorDescription(
+        key="freeze_prevent",
+        translation_key="freeze_prevent",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: (
+            bool(coord.oper_info.get("fFreezePrevent")) if coord.oper_info else None
+        ),
+    ),
+    YardianBinarySensorDescription(
+        key="standby",
+        translation_key="standby",
+        device_class=BinarySensorDeviceClass.POWER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: (
+            bool(coord.oper_info.get("iStandby")) if coord.oper_info else None
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian binary sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        YardianBinarySensor(coordinator, description) for description in SENSORS
+    )
+
+
+class YardianBinarySensor(
+    CoordinatorEntity[YardianUpdateCoordinator], BinarySensorEntity
+):
+    """Define a Yardian binary sensor."""
+
+    entity_description: YardianBinarySensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: YardianUpdateCoordinator,
+        description: YardianBinarySensorDescription,
+    ) -> None:
+        """Initialize Yardian binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.yid}-{description.key}"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the binary sensor is on."""
+        return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/yardian/coordinator.py
+++ b/homeassistant/components/yardian/coordinator.py
@@ -47,24 +47,43 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
         )
 
         self.controller = controller
-        self.yid = entry.data["yid"]
+        self._yid = entry.data["yid"]
         self._name = entry.title
         self._model = entry.data["model"]
+        self._serial_number = entry.data.get("serialNumber")
+        self.oper_info: OperationInfo | None = None
+
+    @property
+    def yid(self) -> str:
+        """Return the controller unique id."""
+        return self._yid
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return information about the device."""
-        return DeviceInfo(
+        info = DeviceInfo(
             name=self._name,
-            identifiers={(DOMAIN, self.yid)},
+            identifiers={(DOMAIN, self._yid)},
             manufacturer=MANUFACTURER,
             model=self._model,
         )
+        if self._serial_number:
+            info["serial_number"] = self._serial_number
+        return info
+
+    @property
+    def serial_number(self) -> str | None:
+        """Return the controller serial number."""
+        return self._serial_number
 
     async def _async_update_data(self) -> YardianDeviceState:
         """Fetch data from Yardian device."""
         try:
             async with asyncio.timeout(10):
+                self.oper_info = await self.controller.fetch_oper_info()
+                if not self._serial_number:
+                    device_info = await self.controller.fetch_device_info()
+                    self._serial_number = device_info.get("serialNumber")
                 return await self.controller.fetch_device_state()
 
         except TimeoutError as e:

--- a/homeassistant/components/yardian/sensor.py
+++ b/homeassistant/components/yardian/sensor.py
@@ -1,0 +1,106 @@
+"""Yardian sensor platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+@dataclass
+class YardianSensorDescription(SensorEntityDescription):
+    """Describe a Yardian sensor."""
+
+    value_fn: Callable[[YardianUpdateCoordinator], Any]
+
+
+SENSORS: tuple[YardianSensorDescription, ...] = (
+    YardianSensorDescription(
+        key="rain_delay",
+        translation_key="rain_delay",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: (
+            coord.oper_info.get("iRainDelay") if coord.oper_info else None
+        ),
+    ),
+    YardianSensorDescription(
+        key="sensor1",
+        translation_key="sensor1",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: (
+            coord.oper_info.get("sensor1", {}).get("value") if coord.oper_info else None
+        ),
+    ),
+    YardianSensorDescription(
+        key="sensor2",
+        translation_key="sensor2",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: (
+            coord.oper_info.get("sensor2", {}).get("value") if coord.oper_info else None
+        ),
+    ),
+    YardianSensorDescription(
+        key="serial_number",
+        translation_key="serial_number",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: coord.serial_number,
+    ),
+    YardianSensorDescription(
+        key="yid",
+        translation_key="yid",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coord: coord.yid,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Yardian sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        YardianSensor(coordinator, description) for description in SENSORS
+    )
+
+
+class YardianSensor(CoordinatorEntity[YardianUpdateCoordinator], SensorEntity):
+    """Define a Yardian sensor."""
+
+    entity_description: YardianSensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: YardianUpdateCoordinator,
+        description: YardianSensorDescription,
+    ) -> None:
+        """Initialize Yardian sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.yid}-{description.key}"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def native_value(self) -> Any:
+        """Return the value for the sensor."""
+        return self.entity_description.value_fn(self.coordinator)


### PR DESCRIPTION
## Summary
- support sensors and binary sensors for Yardian
- expose operation and device data from the coordinator

## Testing
- `black homeassistant/components/yardian/__init__.py homeassistant/components/yardian/coordinator.py homeassistant/components/yardian/sensor.py homeassistant/components/yardian/binary_sensor.py`
- `python3 -m script.hassfest tests/components/yardian/test_config_flow.py` *(fails: ModuleNotFoundError: No module named 'ciso8601')*

------
https://chatgpt.com/codex/tasks/task_e_686f95491ea4832689caa6fc494db50d