### PR TITLE
Improve Daikin zone temperature parsing readability

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.util.ssl import client_context_no_verify
 
+from . import services
 from .const import DOMAIN, KEY_MAC, TIMEOUT
 from .coordinator import DaikinConfigEntry, DaikinCoordinator
 
@@ -71,8 +72,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaikinConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Register Daikin custom services
-    from . import services
-
     await services.async_setup_services(hass)
 
     return True

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -308,14 +308,15 @@ class DaikinClimate(DaikinEntity, ClimateEntity):
         cooling_temps = parse_zone_temps(lztemp_c)
         # Determine current mode
         mode = self.hvac_mode
-        use_heating = mode == HVACMode.HEAT
-        use_cooling = mode == HVACMode.COOL
+        # fmt: off
+        use_heating = (mode == HVACMode.HEAT)
+        use_cooling = (mode == HVACMode.COOL)
+        # fmt: on
         # Only include zones that are ON (switch enabled)
         zone_temps = {}
         if zones:
-            for idx, zone in enumerate(zones):
-                zone_enabled = zone[1] == "1"
-                if not zone_enabled:
+            for idx, (_, enabled) in enumerate(zones):
+                if enabled != "1":
                     continue
                 if use_heating and idx < len(heating_temps):
                     zone_temps[idx] = heating_temps[idx]

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -300,20 +300,22 @@ class DaikinClimate(DaikinEntity, ClimateEntity):
             try:
                 decoded = unquote(val)
                 return [float(x) for x in decoded.split(";")]
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as err:
+                _LOGGER.debug("Invalid zone temperature data '%s': %s", val, err)
                 return []
 
         heating_temps = parse_zone_temps(lztemp_h)
         cooling_temps = parse_zone_temps(lztemp_c)
         # Determine current mode
         mode = self.hvac_mode
-        use_heating = mode == "heat"
-        use_cooling = mode == "cool"
+        use_heating = mode == HVACMode.HEAT
+        use_cooling = mode == HVACMode.COOL
         # Only include zones that are ON (switch enabled)
         zone_temps = {}
         if zones:
-            on_indices = [i for i, z in enumerate(zones) if z[1] == "1"]
-            for i in on_indices:
+            for i, zone in enumerate(zones):
+                if zone[1] != "1":
+                    continue
                 if use_heating and i < len(heating_temps):
                     zone_temps[i] = heating_temps[i]
                 elif use_cooling and i < len(cooling_temps):

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -289,7 +289,7 @@ class DaikinClimate(DaikinEntity, ClimateEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes, mapping zone IDs to set temperatures for ON zones only, for the current mode."""
-        attrs = super().extra_state_attributes or {}
+        attrs = dict(super().extra_state_attributes or {})
         lztemp_h = self.device.values.get("lztemp_h")
         lztemp_c = self.device.values.get("lztemp_c")
         zones = getattr(self.device, "zones", None)
@@ -313,12 +313,13 @@ class DaikinClimate(DaikinEntity, ClimateEntity):
         # Only include zones that are ON (switch enabled)
         zone_temps = {}
         if zones:
-            for i, zone in enumerate(zones):
-                if zone[1] != "1":
+            for idx, zone in enumerate(zones):
+                zone_enabled = zone[1] == "1"
+                if not zone_enabled:
                     continue
-                if use_heating and i < len(heating_temps):
-                    zone_temps[i] = heating_temps[i]
-                elif use_cooling and i < len(cooling_temps):
-                    zone_temps[i] = cooling_temps[i]
+                if use_heating and idx < len(heating_temps):
+                    zone_temps[idx] = heating_temps[idx]
+                elif use_cooling and idx < len(cooling_temps):
+                    zone_temps[idx] = cooling_temps[idx]
         attrs["zone_temps"] = zone_temps
         return attrs

--- a/homeassistant/components/daikin/icons.json
+++ b/homeassistant/components/daikin/icons.json
@@ -23,9 +23,9 @@
       }
     }
   },
-  "service": {
+  "services": {
     "set_zone_temperature": {
-      "default": "mdi:thermometer"
+      "service": "mdi:thermometer"
     }
   }
 }

--- a/homeassistant/components/daikin/icons.json
+++ b/homeassistant/components/daikin/icons.json
@@ -22,5 +22,10 @@
         "default": "mdi:power"
       }
     }
+  },
+  "service": {
+    "set_zone_temperature": {
+      "default": "mdi:thermometer"
+    }
   }
 }

--- a/homeassistant/components/daikin/services.py
+++ b/homeassistant/components/daikin/services.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 SERVICE_SET_ZONE_TEMPERATURE = "set_zone_temperature"
 
 # Track service registration per hass instance
-_services_registered = WeakKeyDictionary()
+_services_registered: WeakKeyDictionary[HomeAssistant, bool] = WeakKeyDictionary()
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/daikin/services.yaml
+++ b/homeassistant/components/daikin/services.yaml
@@ -1,13 +1,11 @@
 set_zone_temperature:
-  name: Set Zone Temperature
-  description: "Set a zone's temperature on a compatible Daikin device. The temperature must be within +/- 2 degrees of the main system's target temperature."
   target:
     entity:
+      integration: daikin
       domain: climate
   fields:
     zone_id:
       required: true
-      description: "ID of the zone (0-10) to set the temperature for"
       selector:
         number:
           min: 0
@@ -16,7 +14,6 @@ set_zone_temperature:
           step: 1
     temperature:
       required: true
-      description: "Temperature to set (in Celsius). Must be within +/- 2 degrees of the main system's target temperature."
       selector:
         number:
           min: 0

--- a/homeassistant/components/daikin/strings.json
+++ b/homeassistant/components/daikin/strings.json
@@ -57,5 +57,21 @@
         "name": "Power"
       }
     }
+  },
+  "services": {
+    "set_zone_temperature": {
+      "name": "Set zone temperature",
+      "description": "Set a zone's temperature on a compatible Daikin device.",
+      "fields": {
+        "zone_id": {
+          "name": "Zone",
+          "description": "ID of the zone (0-10) to set the temperature for"
+        },
+        "temperature": {
+          "name": "Temperature",
+          "description": "Temperature to set (in Celsius). Must be within ±2° of the main system's target temperature"
+        }
+      }
+    }
   }
 }

--- a/tests/components/daikin/test_services.py
+++ b/tests/components/daikin/test_services.py
@@ -25,6 +25,8 @@ if "pydaikin.factory" not in sys.modules:
     fake_factory.DaikinFactory = DaikinFactory
     sys.modules["pydaikin.factory"] = fake_factory
 
+import urllib.parse
+
 import pytest
 import voluptuous as vol
 
@@ -81,8 +83,6 @@ class FakeDevice:
         # Simulate set_zone_setting: update lztemp_h and lztemp_c dicts from values
         if path.startswith("aircon/set_zone_setting"):
             # Parse params from the path
-            import urllib.parse
-
             parsed = urllib.parse.urlparse(path)
             params = urllib.parse.parse_qs(parsed.query)
             lztemp_h_str = params.get("lztemp_h", [""])[0]

--- a/tests/components/daikin/test_services.py
+++ b/tests/components/daikin/test_services.py
@@ -243,7 +243,7 @@ async def test_service_multiple_calls(setup_integration) -> None:
     """Test multiple service calls in quick succession."""
     hass, coordinator = setup_integration
     await services.async_setup_services(hass)
-    for temp in [22, 23, 21]:
+    for temp in (22, 23, 21):
         service_data = {"zone_id": 0, "temperature": temp}
         await hass.services.async_call(
             "daikin", services.SERVICE_SET_ZONE_TEMPERATURE, service_data, blocking=True


### PR DESCRIPTION
## Summary
- log invalid zone temperature values
- simplify zone temperature selection logic
- use HVACMode constants for readability

## Testing
- `pre-commit run --files homeassistant/components/daikin/climate.py` *(fails: mypy requires Python 3.13; pylint option not recognized)*


------
https://chatgpt.com/codex/tasks/task_e_689b1de1919c83269ebc091add1e6932