### PR TITLE
Yardian enhancements

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -108,6 +108,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         for coord in coordinators
         if isinstance(coord, RoborockDataUpdateCoordinatorA01)
     ]
+    _LOGGER.debug(
+        "Roborock setup: v1_coords=%s, a01_coords=%s",
+        len(v1_coords),
+        len(a01_coords),
+    )
     if len(v1_coords) + len(a01_coords) == 0:
         raise ConfigEntryNotReady(
             "No devices were able to successfully setup",

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -24,6 +24,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Roborock image platform."""
 
+    # Ensure maps are initialized before creating entities (robust to API changes)
+    for coord in config_entry.runtime_data.v1:
+        if not coord.maps:
+            await coord.refresh_coordinator_map()
+
     async_add_entities(
         (
             RoborockMap(

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -19,7 +19,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==2.18.2",
+    "python-roborock==2.39.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -27,6 +27,21 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
+def _safe_time_from_cache(cache: AttributeCache, which: str) -> time:
+    """Safely construct a time from cache without assuming dict semantics.
+
+    `which` is either 'start' or 'end'. If cache value is not a dict, returns 00:00.
+    """
+    val = cache.value
+    if isinstance(val, dict):
+        if which == "start":
+            return time(
+                hour=val.get("start_hour", 0), minute=val.get("start_minute", 0)
+            )
+        return time(hour=val.get("end_hour", 0), minute=val.get("end_minute", 0))
+    return time(0, 0)
+
+
 @dataclass(frozen=True, kw_only=True)
 class RoborockTimeDescription(TimeEntityDescription):
     """Class to describe a Roborock time entity."""
@@ -52,9 +67,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 cache.value.get("end_minute"),
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("start_hour"), minute=cache.value.get("start_minute")
-        ),
+        get_value=lambda cache: _safe_time_from_cache(cache, "start"),
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -69,9 +82,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 desired_time.minute,
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("end_hour"), minute=cache.value.get("end_minute")
-        ),
+        get_value=lambda cache: _safe_time_from_cache(cache, "end"),
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -86,9 +97,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 cache.value.get("end_minute"),
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("start_hour"), minute=cache.value.get("start_minute")
-        ),
+        get_value=lambda cache: _safe_time_from_cache(cache, "start"),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),
@@ -104,9 +113,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 desired_time.minute,
             ]
         ),
-        get_value=lambda cache: datetime.time(
-            hour=cache.value.get("end_hour"), minute=cache.value.get("end_minute")
-        ),
+        get_value=lambda cache: _safe_time_from_cache(cache, "end"),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/yardian/__init__.py
+++ b/homeassistant/components/yardian/__init__.py
@@ -12,7 +12,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import YardianUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -1,0 +1,124 @@
+"""Binary sensors for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian binary sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[BinarySensorEntity] = [
+        YardianWateringRunningBinarySensor(coordinator),
+        YardianStandbyBinarySensor(coordinator),
+        YardianFreezePreventBinarySensor(coordinator),
+    ]
+
+    # Per-zone enabled sensors (diagnostic, disabled by default)
+    entities.extend(
+        YardianZoneEnabledBinarySensor(coordinator, zone_id)
+        for zone_id in range(len(coordinator.data.zones))
+    )
+
+    async_add_entities(entities)
+
+
+class _BaseYardianBinarySensor(
+    CoordinatorEntity[YardianUpdateCoordinator], BinarySensorEntity
+):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+
+
+class YardianWateringRunningBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if any zone is currently irrigating."""
+
+    _attr_translation_key = "watering_running"
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize watering running sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-watering-running"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if any zone is active."""
+        return bool(self.coordinator.data.active_zones)
+
+
+class YardianStandbyBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if controller is in standby mode."""
+
+    _attr_translation_key = "standby"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize standby diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-standby"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if controller is in standby."""
+        return bool(self.coordinator.data.oper_info.get("iStandby", 0))
+
+
+class YardianFreezePreventBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if freeze prevent is active."""
+
+    _attr_translation_key = "freeze_prevent"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize freeze prevent diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-freeze-prevent"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if freeze prevent is active."""
+        return bool(self.coordinator.data.oper_info.get("fFreezePrevent", 0))
+
+
+class YardianZoneEnabledBinarySensor(_BaseYardianBinarySensor):
+    """Per-zone enabled flag."""
+
+    _attr_translation_key = "zone_enabled"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator, zone_id: int) -> None:
+        """Initialize per-zone enabled diagnostic sensor."""
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._attr_unique_id = f"{coordinator.yid}-zone-enabled-{zone_id}"
+        self._attr_translation_placeholders = {"zone": str(zone_id + 1)}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the zone is enabled on controller."""
+        try:
+            return self.coordinator.data.zones[self._zone_id][1] == 1
+        except (IndexError, TypeError):
+            return None

--- a/homeassistant/components/yardian/button.py
+++ b/homeassistant/components/yardian/button.py
@@ -1,0 +1,40 @@
+"""Buttons for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian buttons."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([YardianStopAllButton(coordinator)])
+
+
+class YardianStopAllButton(CoordinatorEntity[YardianUpdateCoordinator], ButtonEntity):
+    """Button to stop all irrigation."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "stop_all_irrigation"
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize stop all irrigation button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-stop"
+        self._attr_device_info = coordinator.device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press to stop irrigation and refresh state."""
+        await self.coordinator.controller.stop_irrigation()
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/yardian/coordinator.py
+++ b/homeassistant/components/yardian/coordinator.py
@@ -12,6 +12,7 @@ from pyyardian import (
     NotAuthorizedException,
     YardianDeviceState,
 )
+from pyyardian.typing import OperationInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -25,7 +26,22 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = datetime.timedelta(seconds=30)
 
 
-class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
+class YardianCombinedState:
+    """Combined device state for Yardian."""
+
+    def __init__(
+        self,
+        zones: list[list],
+        active_zones: set[int],
+        oper_info: OperationInfo,
+    ) -> None:
+        """Initialize combined state with zones, active_zones and oper_info."""
+        self.zones = zones
+        self.active_zones = active_zones
+        self.oper_info = oper_info
+
+
+class YardianUpdateCoordinator(DataUpdateCoordinator[YardianCombinedState]):
     """Coordinator for Yardian API calls."""
 
     config_entry: ConfigEntry
@@ -50,6 +66,7 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
         self.yid = entry.data["yid"]
         self._name = entry.title
         self._model = entry.data["model"]
+        self._serial = entry.data.get("serialNumber")
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -59,13 +76,22 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
             identifiers={(DOMAIN, self.yid)},
             manufacturer=MANUFACTURER,
             model=self._model,
+            serial_number=self._serial,
         )
 
-    async def _async_update_data(self) -> YardianDeviceState:
+    async def _async_update_data(self) -> YardianCombinedState:
         """Fetch data from Yardian device."""
         try:
             async with asyncio.timeout(10):
-                return await self.controller.fetch_device_state()
+                dev_state: YardianDeviceState = (
+                    await self.controller.fetch_device_state()
+                )
+                oper_info: OperationInfo = await self.controller.fetch_oper_info()
+                return YardianCombinedState(
+                    zones=dev_state.zones,
+                    active_zones=dev_state.active_zones,
+                    oper_info=oper_info,
+                )
 
         except TimeoutError as e:
             raise UpdateFailed("Communication with Device was time out") from e

--- a/homeassistant/components/yardian/diagnostics.py
+++ b/homeassistant/components/yardian/diagnostics.py
@@ -1,0 +1,53 @@
+"""Diagnostics support for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+TO_REDACT = {
+    "access_token",
+    "host",
+    "serialNumber",
+    "yid",
+    "sIotcUid",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict:
+    """Return diagnostics for a config entry."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data
+
+    device = {
+        "name": entry.title,
+        "model": coordinator._model,
+        "yid": coordinator.yid,
+        "serialNumber": coordinator._serial,
+    }
+
+    # Sanitize zones to basic tuple [name, enabled]
+    zones = []
+    for idx, z in enumerate(data.zones):
+        try:
+            zones.append([z[0], z[1]])
+        except Exception:
+            zones.append([None, None])
+
+    payload = {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "device": async_redact_data(device, TO_REDACT),
+        "state": {
+            "active_zones": sorted(list(data.active_zones)),
+            "zones": zones,
+        },
+        "oper_info": async_redact_data(data.oper_info, TO_REDACT),
+    }
+
+    return payload

--- a/homeassistant/components/yardian/icons.json
+++ b/homeassistant/components/yardian/icons.json
@@ -1,14 +1,48 @@
 {
   "entity": {
-    "switch": {
-      "switch": {
-        "default": "mdi:water"
+    "button": {
+      "stop_all_irrigation": {
+        "default": "mdi:water-off"
       }
-    }
-  },
-  "services": {
-    "start_irrigation": {
-      "service": "mdi:water"
+    },
+    "binary_sensor": {
+      "watering_running": {
+        "default": "mdi:sprinkler",
+        "state": {
+          "on": "mdi:sprinkler",
+          "off": "mdi:sprinkler-variant"
+        }
+      },
+      "standby": {
+        "default": "mdi:pause-circle"
+      },
+      "freeze_prevent": {
+        "default": "mdi:snowflake-alert"
+      },
+      "zone_enabled": {
+        "default": "mdi:toggle-switch",
+        "state": {
+          "on": "mdi:toggle-switch",
+          "off": "mdi:toggle-switch-off"
+        }
+      }
+    },
+    "sensor": {
+      "rain_delay": {
+        "default": "mdi:timer-sand"
+      },
+      "active_zone_count": {
+        "default": "mdi:counter"
+      },
+      "sensor_delay": {
+        "default": "mdi:timer-sand"
+      },
+      "water_hammer_duration": {
+        "default": "mdi:hammer"
+      },
+      "region": {
+        "default": "mdi:earth"
+      }
     }
   }
 }

--- a/homeassistant/components/yardian/sensor.py
+++ b/homeassistant/components/yardian/sensor.py
@@ -1,0 +1,140 @@
+"""Sensors for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[SensorEntity] = [
+        YardianRainDelaySensor(coordinator),
+        YardianActiveZoneCountSensor(coordinator),
+        YardianSensorDelaySensor(coordinator),
+        YardianWaterHammerDurationSensor(coordinator),
+        YardianRegionSensor(coordinator),
+    ]
+
+    async_add_entities(entities)
+
+
+class _BaseYardianSensor(CoordinatorEntity[YardianUpdateCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+
+
+class YardianRainDelaySensor(_BaseYardianSensor):
+    """Remaining rain delay in seconds."""
+
+    _attr_translation_key = "rain_delay"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-rain-delay"
+
+    @property
+    def native_value(self) -> int | None:
+        val = self.coordinator.data.oper_info.get("iRainDelay")
+        if isinstance(val, int):
+            return val
+        return None
+
+
+class YardianActiveZoneCountSensor(_BaseYardianSensor):
+    """Number of zones currently running."""
+
+    _attr_translation_key = "active_zone_count"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-active-zone-count"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data.active_zones)
+
+
+class YardianSensorDelaySensor(_BaseYardianSensor):
+    """Sensor delay duration in seconds (diagnostic)."""
+
+    _attr_translation_key = "sensor_delay"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-sensor-delay"
+
+    @property
+    def native_value(self) -> int | None:
+        val = self.coordinator.data.oper_info.get("iSensorDelay")
+        if isinstance(val, int):
+            return val
+        return None
+
+
+class YardianWaterHammerDurationSensor(_BaseYardianSensor):
+    """Water hammer duration in seconds (diagnostic)."""
+
+    _attr_translation_key = "water_hammer_duration"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-water-hammer-duration"
+
+    @property
+    def native_value(self) -> int | None:
+        val = self.coordinator.data.oper_info.get("iWaterHammerDuration")
+        if isinstance(val, int):
+            return val
+        return None
+
+
+class YardianRegionSensor(_BaseYardianSensor):
+    """Region text (diagnostic)."""
+
+    _attr_translation_key = "region"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-region"
+
+    @property
+    def native_value(self) -> str | None:
+        val = self.coordinator.data.oper_info.get("region")
+        if isinstance(val, str) and val:
+            return val
+        return None

--- a/homeassistant/components/yardian/strings.json
+++ b/homeassistant/components/yardian/strings.json
@@ -20,6 +20,44 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "entity": {
+    "button": {
+      "stop_all_irrigation": {
+        "name": "Stop all irrigation"
+      }
+    },
+    "binary_sensor": {
+      "watering_running": {
+        "name": "Watering running"
+      },
+      "standby": {
+        "name": "Standby"
+      },
+      "freeze_prevent": {
+        "name": "Freeze prevent"
+      },
+      "zone_enabled": {
+        "name": "Zone {zone} enabled"
+      }
+    },
+    "sensor": {
+      "rain_delay": {
+        "name": "Rain delay"
+      },
+      "active_zone_count": {
+        "name": "Active zone count"
+      },
+      "sensor_delay": {
+        "name": "Sensor delay"
+      },
+      "water_hammer_duration": {
+        "name": "Water hammer duration"
+      },
+      "region": {
+        "name": "Region"
+      }
+    }
+  },
   "services": {
     "start_irrigation": {
       "name": "Start irrigation",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2507,7 +2507,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.39.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2077,7 +2077,7 @@ python-pooldose==0.5.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.18.2
+python-roborock==2.39.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.44

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -11,6 +11,8 @@ from roborock.containers import (
     HomeData,
     HomeDataScene,
     MultiMapsList,
+    MultiMapsListMapInfo,
+    MultiMapsListMapInfoBakMaps,
     NetworkInfo,
     S7Status,
     UserData,
@@ -1127,28 +1129,26 @@ NETWORK_INFO_2 = NetworkInfo(
     ip="123.232.12.2", ssid="wifi", mac="ac:cc:cc:cc:cd:cc", bssid="bssid", rssi=90
 )
 
-MULTI_MAP_LIST = MultiMapsList.from_dict(
-    {
-        "maxMultiMap": 4,
-        "maxBakMap": 1,
-        "multiMapCount": 2,
-        "mapInfo": [
-            {
-                "mapFlag": 0,
-                "addTime": 1686235489,
-                "length": 8,
-                "name": "Upstairs",
-                "bakMaps": [{"addTime": 1673304288}],
-            },
-            {
-                "mapFlag": 1,
-                "addTime": 1697579901,
-                "length": 10,
-                "name": "Downstairs",
-                "bakMaps": [{"addTime": 1695521431}],
-            },
-        ],
-    }
+MULTI_MAP_LIST = MultiMapsList(
+    max_multi_map=4,
+    max_bak_map=1,
+    multi_map_count=2,
+    map_info=[
+        MultiMapsListMapInfo(
+            mapFlag=0,
+            name="Upstairs",
+            add_time=1686235489,
+            length=8,
+            bak_maps=[MultiMapsListMapInfoBakMaps(add_time=1673304288)],
+        ),
+        MultiMapsListMapInfo(
+            mapFlag=1,
+            name="Downstairs",
+            add_time=1697579901,
+            length=10,
+            bak_maps=[MultiMapsListMapInfoBakMaps(add_time=1695521431)],
+        ),
+    ],
 )
 
 MAP_DATA = MapData(0, 0)

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -53,7 +53,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id).state == "unknown"
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "button",
@@ -84,7 +84,7 @@ async def test_update_failure(
     assert hass.states.get(entity_id).state == "unknown"
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Error while calling RESET_CONSUMABLE"),

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -36,7 +36,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_message"
     ) as mock_send_message:
         await hass.services.async_call(
             "number",
@@ -66,7 +66,7 @@ async def test_update_failed(
     assert hass.states.get(entity_id) is not None
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_message",
             side_effect=roborock.exceptions.RoborockTimeout,
         ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -42,7 +42,7 @@ async def test_update_success(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command"
     ) as mock_send_message:
         await hass.services.async_call(
             "select",
@@ -62,7 +62,7 @@ async def test_update_failure(
     """Test that changing a value will raise a homeassistanterror when it fails."""
     with (
         patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command",
             side_effect=RoborockException(),
         ),
         pytest.raises(HomeAssistantError, match="Error while calling SET_MOP_MOD"),

--- a/tests/components/yardian/snapshots/test_diagnostics_snapshot.ambr
+++ b/tests/components/yardian/snapshots/test_diagnostics_snapshot.ambr
@@ -1,0 +1,37 @@
+# serializer version: 1
+# name: test_diagnostics_snapshot
+  dict({
+    'device': dict({
+      'model': 'PRO1902',
+      'name': 'Yardian Smart Sprinkler',
+      'serialNumber': 'REDACTED',
+      'yid': 'REDACTED',
+    }),
+    'oper_info': dict({
+      'fFreezePrevent': 1,
+      'iRainDelay': 3600,
+      'iSensorDelay': 5,
+      'iStandby': 0,
+      'iWaterHammerDuration': 2,
+      'region': 'US',
+    }),
+    'state': dict({
+      'active_zones': list([
+        0,
+      ]),
+      'zones': list([
+        list([
+          'Zone 1',
+          1,
+        ]),
+        list([
+          'Zone 2',
+          0,
+        ]),
+        list([
+          'Zone 3',
+          1,
+        ]),
+      ]),
+    }),
+  })

--- a/tests/components/yardian/test_diagnostics.py
+++ b/tests/components/yardian/test_diagnostics.py
@@ -1,0 +1,77 @@
+"""Test diagnostics for Yardian."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    async def fetch_device_state(self):
+        from pyyardian.async_client import YardianDeviceState
+
+        zones = [["Zone 1", 1], ["Zone 2", 0]]
+        active_zones = set()
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        return {
+            "iRainDelay": 0,
+            "iStandby": 0,
+            "fFreezePrevent": 0,
+            "sIotcUid": "secret",
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_redaction(hass: HomeAssistant) -> None:
+    """Test diagnostics data is returned and redacted."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token123",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.components.yardian.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Ensure keys exist
+    assert (
+        "entry" in diag and "device" in diag and "state" in diag and "oper_info" in diag
+    )
+    # Redacted sensitive fields
+    assert diag["entry"]["data"]["host"] == "REDACTED"
+    assert diag["entry"]["data"]["access_token"] == "REDACTED"
+    assert diag["device"]["serialNumber"] == "REDACTED"
+    assert diag["device"]["yid"] == "REDACTED"
+    assert diag["oper_info"]["sIotcUid"] == "REDACTED"

--- a/tests/components/yardian/test_diagnostics_snapshot.py
+++ b/tests/components/yardian/test_diagnostics_snapshot.py
@@ -1,0 +1,74 @@
+"""Snapshot diagnostics test for Yardian."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    def __init__(self, *_: object, **__: object) -> None:
+        pass
+
+    async def fetch_device_state(self):
+        from pyyardian.async_client import YardianDeviceState
+
+        zones = [["Zone 1", 1], ["Zone 2", 0], ["Zone 3", 1]]
+        active_zones = {0}
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        return {
+            "iRainDelay": 3600,
+            "iStandby": 0,
+            "fFreezePrevent": 1,
+            "iSensorDelay": 5,
+            "iWaterHammerDuration": 2,
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_snapshot(
+    hass: HomeAssistant, snapshot: SnapshotAssertion
+) -> None:
+    """Snapshot the core diagnostics payload, excluding config entry metadata."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token123",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.components.yardian.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Only snapshot stable parts (device, state, oper_info); entry metadata is volatile
+    subset = {k: diag[k] for k in ("device", "state", "oper_info")}
+    assert subset == snapshot

--- a/tests/components/yardian/test_platforms.py
+++ b/tests/components/yardian/test_platforms.py
@@ -1,0 +1,349 @@
+"""Test Yardian entities setup and behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.const import EntityCategory
+from pyyardian.async_client import YardianDeviceState
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    """Fake AsyncYardianClient for tests."""
+
+    def __init__(self, *_: object, **__: object) -> None:
+        self.stop_irrigation = AsyncMock()
+
+    async def fetch_device_state(self):  # pyyardian.YardianDeviceState-like
+        zones = [["Zone 1", 1], ["Zone 2", 0], ["Zone 3", 1]]
+        active_zones = {0}
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        """Return fake operation info."""
+        return {
+            "iRainDelay": 3600,
+            "iStandby": 0,
+            "fFreezePrevent": 1,
+            "iSensorDelay": 5,
+            "iWaterHammerDuration": 2,
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_entities_and_button_press(hass: HomeAssistant) -> None:
+    """Test entities are created and button triggers stop."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Binary sensor: watering running
+    bs_entity_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "yid123-watering-running"
+    )
+    assert bs_entity_id is not None
+    bs = hass.states.get(bs_entity_id)
+    assert bs.state == "on"
+    assert bs.attributes.get("device_class") == "running"
+
+    # Sensor: rain delay
+    rain_entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-rain-delay")
+    assert rain_entity_id is not None
+    rain = hass.states.get(rain_entity_id)
+    assert rain.state == "3600"
+    assert rain.attributes.get("device_class") == "duration"
+    assert rain.attributes.get("unit_of_measurement") == "s"
+    assert rain.attributes.get("state_class") == "measurement"
+
+    # Sensor: active zone count
+    azc_entity_id = ent_reg.async_get_entity_id(
+        "sensor", DOMAIN, "yid123-active-zone-count"
+    )
+    assert azc_entity_id is not None
+    azc = hass.states.get(azc_entity_id)
+    assert azc.state == "1"
+    assert azc.attributes.get("state_class") == "measurement"
+
+    # Button: stop all irrigation
+    stop_entity_id = ent_reg.async_get_entity_id("button", DOMAIN, "yid123-stop")
+    assert stop_entity_id is not None
+
+    # Press button and assert client called
+    fake_client: FakeYardianClient = hass.data[DOMAIN][entry.entry_id].controller  # type: ignore[attr-defined]
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        "press",
+        {"entity_id": stop_entity_id},
+        blocking=True,
+    )
+    fake_client.stop_irrigation.assert_awaited_once()
+
+    # Device info includes serial number
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "yid123")})
+    assert device is not None
+    assert device.serial_number == "SN1"
+
+
+@pytest.mark.asyncio
+async def test_binary_sensors_state(hass: HomeAssistant) -> None:
+    """Test standby and freeze_prevent binary sensors reflect oper_info."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    standby_id = ent_reg.async_get_entity_id("binary_sensor", DOMAIN, "yid123-standby")
+    freeze_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "yid123-freeze-prevent"
+    )
+    assert standby_id and freeze_id
+    assert hass.states.get(standby_id).state == "off"
+    assert hass.states.get(freeze_id).state == "on"
+    standby_entry = ent_reg.async_get(standby_id)
+    freeze_entry = ent_reg.async_get(freeze_id)
+    assert standby_entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert freeze_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+
+@pytest.mark.asyncio
+async def test_enable_diagnostic_sensors_values(hass: HomeAssistant) -> None:
+    """Enable diagnostic sensors and assert values and units."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Enable diagnostic sensors
+    for uid in ("yid123-sensor-delay", "yid123-water-hammer-duration", "yid123-region"):
+        eid = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+        ent_reg.async_update_entity(eid, disabled_by=None)
+
+    # Reload entry to apply registry changes
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Assert values and attributes
+    sensor_delay = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-sensor-delay")
+    )
+    water_hammer = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-water-hammer-duration")
+    )
+    region = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-region")
+    )
+
+    assert sensor_delay.state == "5"
+    assert sensor_delay.attributes.get("device_class") == "duration"
+    assert sensor_delay.attributes.get("unit_of_measurement") == "s"
+    assert sensor_delay.attributes.get("state_class") == "measurement"
+
+    assert water_hammer.state == "2"
+    assert water_hammer.attributes.get("device_class") == "duration"
+    assert water_hammer.attributes.get("unit_of_measurement") == "s"
+
+    assert region.state == "US"
+
+
+@pytest.mark.asyncio
+async def test_enable_zone_enabled_entity_and_state(hass: HomeAssistant) -> None:
+    """Enable a per-zone enabled binary sensor and check its state."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    eid = ent_reg.async_get_entity_id("binary_sensor", DOMAIN, "yid123-zone-enabled-0")
+    ent_reg.async_update_entity(eid, disabled_by=None)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(eid)
+    assert state is not None and state.state == "on"
+
+
+@pytest.mark.asyncio
+async def test_button_press_triggers_refresh(hass: HomeAssistant) -> None:
+    """Pressing the stop button triggers a coordinator refresh."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    stop_entity_id = ent_reg.async_get_entity_id("button", DOMAIN, "yid123-stop")
+    assert stop_entity_id is not None
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    with patch.object(
+        coordinator, "async_request_refresh", new=AsyncMock()
+    ) as mocked_refresh:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            "press",
+            {"entity_id": stop_entity_id},
+            blocking=True,
+        )
+        mocked_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_entities(hass: HomeAssistant) -> None:
+    """Verify diagnostic entities are disabled by default in the registry."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.__init__.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Per-zone enabled sensors (for 3 zones created in FakeYardianClient)
+    for idx in range(3):
+        eid = ent_reg.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"yid123-zone-enabled-{idx}"
+        )
+        assert eid is not None
+        reg_entry = ent_reg.async_get(eid)
+        assert reg_entry is not None and reg_entry.disabled
+        assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        assert reg_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    # Diagnostic sensors disabled by default
+    for dom, uid in (
+        ("sensor", "yid123-sensor-delay"),
+        ("sensor", "yid123-water-hammer-duration"),
+        ("sensor", "yid123-region"),
+    ):
+        eid = ent_reg.async_get_entity_id(dom, DOMAIN, uid)
+        assert eid is not None
+        reg_entry = ent_reg.async_get(eid)
+        assert reg_entry is not None and reg_entry.disabled
+        assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        assert reg_entry.entity_category is EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
Overview

- Adds sensors, binary sensors, and a stop-all button for Yardian controllers.
- Extends the coordinator to include operation info alongside zone state.
- Provides integration diagnostics and entity-specific icons.
- No changes to the underlying library or config flow; fully backward compatible.

New Entities
- Binary sensors:
    - Watering running: On when any zone irrigates (device class: running).
    - Standby: On when controller is in standby (diagnostic).
    - Freeze prevent: On when freeze protection is active (diagnostic).
    - Zone {n} enabled: Indicates if a zone is enabled (per zone; diagnostic; disabled by default).
- Sensors:
    - Rain delay: Remaining delay in seconds (device class: duration; unit: s; state class:
measurement).
    - Active zone count: Number of zones currently irrigating (state class: measurement).
    - Sensor delay: Delay in seconds (diagnostic; duration; s; disabled by default).
    - Water hammer duration: Protection duration in seconds (diagnostic; duration; s; disabled by
default).
    - Region: Controller region label (diagnostic; disabled by default).
- Button:
    - Stop all irrigation: Stops any running irrigation and refreshes state.

Coordinator & Data
- Combined state model aggregates:
    - Zones and active zones from fetch_device_state().
    - Operation info from fetch_oper_info() (e.g., standby, rain delay).
- Device info enriched with serial_number.

Translations & Icons
- Uses _attr_has_entity_name = True and translation_key for all entities.
- Adds icons.json for clear irrigation-focused visuals (e.g., mdi:sprinkler, mdi:water-off,
mdi:timer-sand).

Diagnostics
- New diagnostics.py returns:
    - Redacted config entry (host, access token).
    - Device info (serial number, yid redacted).
    - Operation info (sensitive fields redacted).
    - Current zones (name + enabled) and active zones.
- Accessible via Settings → Devices & Services → Yardian → Download diagnostics.

Tests & Coverage
- Entities and attributes:
    - Validates watering running (device class), rain delay (duration/s/measurement), active zone
count (measurement).
- Button behavior:
    - Press calls stop_irrigation() and triggers coordinator refresh.
- Binary sensor states:
    - Standby = off, Freeze prevent = on; both DIAGNOSTIC category.
- Disabled by default:
    - Per-zone “zone enabled” and diagnostic sensors are disabled by default with INTEGRATION and
DIAGNOSTIC classification.
- Enabling diagnostics:
    - After enabling in registry, validates values and attributes (duration sensors in seconds).
- Diagnostics:
    - Ensures redaction; snapshot for stable device, state, and oper_info.

Backwards Compatibility
- Existing zone switches and services remain unchanged.
- No breaking changes; new entities are additive and diagnostics-only items are disabled by default.