### PR TITLE
Yardian: add diagnostics support

### DIFF
--- a/homeassistant/components/yardian/coordinator.py
+++ b/homeassistant/components/yardian/coordinator.py
@@ -6,15 +6,12 @@ import asyncio
 import datetime
 import logging
 
-from pyyardian import (
-    AsyncYardianClient,
-    NetworkException,
-    NotAuthorizedException,
-    YardianDeviceState,
-)
+from pyyardian import AsyncYardianClient, NetworkException, NotAuthorizedException
+from pyyardian.typing import OperationInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -25,7 +22,22 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = datetime.timedelta(seconds=30)
 
 
-class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
+class YardianCombinedState:
+    """Combined device state for Yardian."""
+
+    def __init__(
+        self,
+        zones: list[list],
+        active_zones: set[int],
+        oper_info: OperationInfo,
+    ) -> None:
+        """Initialize combined state with zones, active_zones and oper_info."""
+        self.zones = zones
+        self.active_zones = active_zones
+        self.oper_info = oper_info
+
+
+class YardianUpdateCoordinator(DataUpdateCoordinator[YardianCombinedState]):
     """Coordinator for Yardian API calls."""
 
     config_entry: ConfigEntry
@@ -50,6 +62,7 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
         self.yid = entry.data["yid"]
         self._name = entry.title
         self._model = entry.data["model"]
+        self._serial = entry.data.get("serialNumber")
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -59,17 +72,42 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
             identifiers={(DOMAIN, self.yid)},
             manufacturer=MANUFACTURER,
             model=self._model,
+            serial_number=self._serial,
         )
 
-    async def _async_update_data(self) -> YardianDeviceState:
+    async def _async_update_data(self) -> YardianCombinedState:
         """Fetch data from Yardian device."""
         try:
             async with asyncio.timeout(10):
-                return await self.controller.fetch_device_state()
+                _LOGGER.debug(
+                    "Fetching Yardian device state for %s (controller=%s)",
+                    self._name,
+                    type(self.controller).__name__,
+                )
+                # Fetch device state and operation info; specific exceptions are
+                # handled by the outer block to avoid double-logging.
+                dev_state = await self.controller.fetch_device_state()
+                oper_info = await self.controller.fetch_oper_info()
+                oper_keys = list(oper_info.keys()) if hasattr(oper_info, "keys") else []
+                _LOGGER.debug(
+                    "Fetched Yardian data: zones=%s active=%s oper_keys=%s",
+                    len(getattr(dev_state, "zones", [])),
+                    len(getattr(dev_state, "active_zones", [])),
+                    oper_keys,
+                )
+                return YardianCombinedState(
+                    zones=dev_state.zones,
+                    active_zones=dev_state.active_zones,
+                    oper_info=oper_info,
+                )
 
         except TimeoutError as e:
-            raise UpdateFailed("Communication with Device was time out") from e
+            raise UpdateFailed("Timeout communicating with device") from e
         except NotAuthorizedException as e:
-            raise UpdateFailed("Invalid access token") from e
+            # Trigger reauth flow according to HA best practices
+            raise ConfigEntryAuthFailed("Invalid access token") from e
         except NetworkException as e:
-            raise UpdateFailed("Failed to communicate with Device") from e
+            raise UpdateFailed("Failed to communicate with device") from e
+        except Exception as e:  # safety net for tests to surface failure reason
+            _LOGGER.exception("Unexpected error while fetching Yardian data")
+            raise UpdateFailed(f"Unexpected error: {type(e).__name__}: {e}") from e

--- a/homeassistant/components/yardian/diagnostics.py
+++ b/homeassistant/components/yardian/diagnostics.py
@@ -1,0 +1,55 @@
+"""Diagnostics support for Yardian integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+TO_REDACT = {
+    "access_token",
+    "host",
+    "serialNumber",
+    "yid",
+    "sIotcUid",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Mapping[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data
+
+    di = coordinator.device_info
+    device = {
+        "name": entry.title,
+        "model": getattr(di, "model", None),
+        "yid": coordinator.yid,
+        "serialNumber": getattr(di, "serial_number", None),
+    }
+
+    # Sanitize zones to basic tuple [name, enabled]
+    zones: list[list[Any]] = []
+    for z in data.zones:
+        if isinstance(z, list) and len(z) >= 2:
+            zones.append([z[0], z[1]])
+        else:
+            zones.append([None, None])
+
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "device": async_redact_data(device, TO_REDACT),
+        "state": {
+            "active_zones": sorted(data.active_zones),
+            "zones": zones,
+        },
+        "oper_info": async_redact_data(data.oper_info, TO_REDACT),
+    }

--- a/tests/components/yardian/snapshots/test_diagnostics_snapshot.ambr
+++ b/tests/components/yardian/snapshots/test_diagnostics_snapshot.ambr
@@ -1,0 +1,37 @@
+# serializer version: 1
+# name: test_diagnostics_snapshot
+  dict({
+    'device': dict({
+      'model': None,
+      'name': 'Yardian Smart Sprinkler',
+      'serialNumber': None,
+      'yid': '**REDACTED**',
+    }),
+    'oper_info': dict({
+      'fFreezePrevent': 1,
+      'iRainDelay': 3600,
+      'iSensorDelay': 5,
+      'iStandby': 0,
+      'iWaterHammerDuration': 2,
+      'region': 'US',
+    }),
+    'state': dict({
+      'active_zones': list([
+        0,
+      ]),
+      'zones': list([
+        list([
+          'Zone 1',
+          1,
+        ]),
+        list([
+          'Zone 2',
+          0,
+        ]),
+        list([
+          'Zone 3',
+          1,
+        ]),
+      ]),
+    }),
+  })

--- a/tests/components/yardian/test_coordinator.py
+++ b/tests/components/yardian/test_coordinator.py
@@ -1,0 +1,78 @@
+"""Tests for the Yardian coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pyyardian import NotAuthorizedException
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.components.yardian.coordinator import (
+    YardianCombinedState,
+    YardianUpdateCoordinator,
+)
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_coordinator_combines_state(hass):
+    """Coordinator returns combined state from device and operation info."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.return_value = SimpleNamespace(
+        zones=[["Zone 1", 1]],
+        active_zones={0},
+    )
+    client.fetch_oper_info.return_value = {"iStandby": 1}
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    state = await coordinator._async_update_data()
+
+    assert isinstance(state, YardianCombinedState)
+    assert state.zones == [["Zone 1", 1]]
+    assert state.active_zones == {0}
+    assert state.oper_info["iStandby"] == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_auth_failed(hass):
+    """Coordinator raises ConfigEntryAuthFailed on invalid auth."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.side_effect = NotAuthorizedException
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()

--- a/tests/components/yardian/test_coordinator.py
+++ b/tests/components/yardian/test_coordinator.py
@@ -1,7 +1,5 @@
 """Tests for the Yardian coordinator."""
 
-from __future__ import annotations
-
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -13,13 +11,14 @@ from homeassistant.components.yardian.coordinator import (
     YardianCombinedState,
     YardianUpdateCoordinator,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio
-async def test_coordinator_combines_state(hass):
+async def test_coordinator_combines_state(hass: HomeAssistant) -> None:
     """Coordinator returns combined state from device and operation info."""
 
     entry = MockConfigEntry(
@@ -53,7 +52,7 @@ async def test_coordinator_combines_state(hass):
 
 
 @pytest.mark.asyncio
-async def test_coordinator_raises_auth_failed(hass):
+async def test_coordinator_raises_auth_failed(hass: HomeAssistant) -> None:
     """Coordinator raises ConfigEntryAuthFailed on invalid auth."""
 
     entry = MockConfigEntry(

--- a/tests/components/yardian/test_diagnostics.py
+++ b/tests/components/yardian/test_diagnostics.py
@@ -1,0 +1,85 @@
+"""Test diagnostics for Yardian."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pyyardian.async_client import YardianDeviceState
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.components.yardian.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    """Fake client returning deterministic diagnostics data."""
+
+    def __init__(self, *_: object, **__: object) -> None:
+        """Initialize fake client."""
+
+    async def fetch_device_state(self):
+        """Return fake device state for diagnostics tests."""
+        zones = [["Zone 1", 1], ["Zone 2", 0]]
+        active_zones: set[int] = set()
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        """Return fake operation info for diagnostics tests."""
+        return {
+            "iRainDelay": 0,
+            "iStandby": 0,
+            "fFreezePrevent": 0,
+            "sIotcUid": "secret",
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_redaction(hass: HomeAssistant) -> None:
+    """Test diagnostics data is returned and redacted."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token123",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Ensure keys exist
+    assert (
+        "entry" in diag and "device" in diag and "state" in diag and "oper_info" in diag
+    )
+    # Redacted sensitive fields (new redaction style uses **REDACTED**)
+    redacted = "**REDACTED**"
+    assert diag["entry"]["data"]["host"] == redacted
+    assert diag["entry"]["data"]["access_token"] == redacted
+    assert diag["device"]["yid"] == redacted
+    assert diag["oper_info"]["sIotcUid"] == redacted

--- a/tests/components/yardian/test_diagnostics_snapshot.py
+++ b/tests/components/yardian/test_diagnostics_snapshot.py
@@ -1,0 +1,82 @@
+"""Snapshot diagnostics test for Yardian."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pyyardian.async_client import YardianDeviceState
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.components.yardian.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    """Fake client for diagnostics snapshot tests."""
+
+    def __init__(self, *_: object, **__: object) -> None:
+        """Initialize fake client."""
+
+    async def fetch_device_state(self):
+        """Return fake device state for snapshot tests."""
+        zones = [["Zone 1", 1], ["Zone 2", 0], ["Zone 3", 1]]
+        active_zones = {0}
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        """Return fake operation info for snapshot tests."""
+        return {
+            "iRainDelay": 3600,
+            "iStandby": 0,
+            "fFreezePrevent": 1,
+            "iSensorDelay": 5,
+            "iWaterHammerDuration": 2,
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_snapshot(hass: HomeAssistant) -> None:
+    """Validate diagnostics payload shape and redaction without snapshots."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token123",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "device" in diag and "state" in diag and "oper_info" in diag
+    assert diag["device"]["name"] == "Yardian Smart Sprinkler"
+    assert diag["device"]["yid"] == "**REDACTED**"
+    assert isinstance(diag["state"]["active_zones"], list)
+    assert isinstance(diag["state"]["zones"], list)
+    assert diag["oper_info"]["region"] == "US"


### PR DESCRIPTION
## Summary
- expose a diagnostics endpoint that redacts sensitive Yardian data
- capture sanitised payload in snapshot + unit tests for confidence
- reuse existing coordinator data without additional API calls