### PR TITLE
Yardian: adjust switch defaults and add service tests

### DIFF
--- a/homeassistant/components/yardian/__init__.py
+++ b/homeassistant/components/yardian/__init__.py
@@ -12,7 +12,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import YardianUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/yardian/binary_sensor.py
+++ b/homeassistant/components/yardian/binary_sensor.py
@@ -1,0 +1,124 @@
+"""Binary sensors for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian binary sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[BinarySensorEntity] = [
+        YardianWateringRunningBinarySensor(coordinator),
+        YardianStandbyBinarySensor(coordinator),
+        YardianFreezePreventBinarySensor(coordinator),
+    ]
+
+    # Per-zone enabled sensors (diagnostic, disabled by default)
+    entities.extend(
+        YardianZoneEnabledBinarySensor(coordinator, zone_id)
+        for zone_id in range(len(coordinator.data.zones))
+    )
+
+    async_add_entities(entities)
+
+
+class _BaseYardianBinarySensor(
+    CoordinatorEntity[YardianUpdateCoordinator], BinarySensorEntity
+):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+
+
+class YardianWateringRunningBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if any zone is currently irrigating."""
+
+    _attr_translation_key = "watering_running"
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize watering running sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-watering-running"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if any zone is active."""
+        return bool(self.coordinator.data.active_zones)
+
+
+class YardianStandbyBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if controller is in standby mode."""
+
+    _attr_translation_key = "standby"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize standby diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-standby"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if controller is in standby."""
+        return bool(self.coordinator.data.oper_info.get("iStandby", 0))
+
+
+class YardianFreezePreventBinarySensor(_BaseYardianBinarySensor):
+    """Indicates if freeze prevent is active."""
+
+    _attr_translation_key = "freeze_prevent"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize freeze prevent diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-freeze-prevent"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if freeze prevent is active."""
+        return bool(self.coordinator.data.oper_info.get("fFreezePrevent", 0))
+
+
+class YardianZoneEnabledBinarySensor(_BaseYardianBinarySensor):
+    """Per-zone enabled flag."""
+
+    _attr_translation_key = "zone_enabled"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator, zone_id: int) -> None:
+        """Initialize per-zone enabled diagnostic sensor."""
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._attr_unique_id = f"{coordinator.yid}-zone-enabled-{zone_id}"
+        self._attr_translation_placeholders = {"zone": str(zone_id + 1)}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the zone is enabled on controller."""
+        try:
+            return self.coordinator.data.zones[self._zone_id][1] == 1
+        except (IndexError, TypeError):
+            return None

--- a/homeassistant/components/yardian/coordinator.py
+++ b/homeassistant/components/yardian/coordinator.py
@@ -6,15 +6,12 @@ import asyncio
 import datetime
 import logging
 
-from pyyardian import (
-    AsyncYardianClient,
-    NetworkException,
-    NotAuthorizedException,
-    YardianDeviceState,
-)
+from pyyardian import AsyncYardianClient, NetworkException, NotAuthorizedException
+from pyyardian.typing import OperationInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -25,7 +22,22 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = datetime.timedelta(seconds=30)
 
 
-class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
+class YardianCombinedState:
+    """Combined device state for Yardian."""
+
+    def __init__(
+        self,
+        zones: list[list],
+        active_zones: set[int],
+        oper_info: OperationInfo,
+    ) -> None:
+        """Initialize combined state with zones, active_zones and oper_info."""
+        self.zones = zones
+        self.active_zones = active_zones
+        self.oper_info = oper_info
+
+
+class YardianUpdateCoordinator(DataUpdateCoordinator[YardianCombinedState]):
     """Coordinator for Yardian API calls."""
 
     config_entry: ConfigEntry
@@ -50,6 +62,7 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
         self.yid = entry.data["yid"]
         self._name = entry.title
         self._model = entry.data["model"]
+        self._serial = entry.data.get("serialNumber")
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -59,17 +72,42 @@ class YardianUpdateCoordinator(DataUpdateCoordinator[YardianDeviceState]):
             identifiers={(DOMAIN, self.yid)},
             manufacturer=MANUFACTURER,
             model=self._model,
+            serial_number=self._serial,
         )
 
-    async def _async_update_data(self) -> YardianDeviceState:
+    async def _async_update_data(self) -> YardianCombinedState:
         """Fetch data from Yardian device."""
         try:
             async with asyncio.timeout(10):
-                return await self.controller.fetch_device_state()
+                _LOGGER.debug(
+                    "Fetching Yardian device state for %s (controller=%s)",
+                    self._name,
+                    type(self.controller).__name__,
+                )
+                # Fetch device state and operation info; specific exceptions are
+                # handled by the outer block to avoid double-logging.
+                dev_state = await self.controller.fetch_device_state()
+                oper_info = await self.controller.fetch_oper_info()
+                oper_keys = list(oper_info.keys()) if hasattr(oper_info, "keys") else []
+                _LOGGER.debug(
+                    "Fetched Yardian data: zones=%s active=%s oper_keys=%s",
+                    len(getattr(dev_state, "zones", [])),
+                    len(getattr(dev_state, "active_zones", [])),
+                    oper_keys,
+                )
+                return YardianCombinedState(
+                    zones=dev_state.zones,
+                    active_zones=dev_state.active_zones,
+                    oper_info=oper_info,
+                )
 
         except TimeoutError as e:
-            raise UpdateFailed("Communication with Device was time out") from e
+            raise UpdateFailed("Timeout communicating with device") from e
         except NotAuthorizedException as e:
-            raise UpdateFailed("Invalid access token") from e
+            # Trigger reauth flow according to HA best practices
+            raise ConfigEntryAuthFailed("Invalid access token") from e
         except NetworkException as e:
-            raise UpdateFailed("Failed to communicate with Device") from e
+            raise UpdateFailed("Failed to communicate with device") from e
+        except Exception as e:  # safety net for tests to surface failure reason
+            _LOGGER.exception("Unexpected error while fetching Yardian data")
+            raise UpdateFailed(f"Unexpected error: {type(e).__name__}: {e}") from e

--- a/homeassistant/components/yardian/icons.json
+++ b/homeassistant/components/yardian/icons.json
@@ -1,14 +1,48 @@
 {
   "entity": {
-    "switch": {
-      "switch": {
-        "default": "mdi:water"
+    "binary_sensor": {
+      "watering_running": {
+        "default": "mdi:sprinkler",
+        "state": {
+          "on": "mdi:sprinkler",
+          "off": "mdi:sprinkler-variant"
+        }
+      },
+      "standby": {
+        "default": "mdi:pause-circle"
+      },
+      "freeze_prevent": {
+        "default": "mdi:snowflake-alert"
+      },
+      "zone_enabled": {
+        "default": "mdi:toggle-switch",
+        "state": {
+          "on": "mdi:toggle-switch",
+          "off": "mdi:toggle-switch-off"
+        }
+      }
+    },
+    "sensor": {
+      "rain_delay": {
+        "default": "mdi:timer-sand"
+      },
+      "active_zone_count": {
+        "default": "mdi:counter"
+      },
+      "sensor_delay": {
+        "default": "mdi:timer-sand"
+      },
+      "water_hammer_duration": {
+        "default": "mdi:hammer"
+      },
+      "region": {
+        "default": "mdi:earth"
       }
     }
   },
   "services": {
     "start_irrigation": {
-      "service": "mdi:water"
+      "service": "mdi:sprinkler"
     }
   }
 }

--- a/homeassistant/components/yardian/sensor.py
+++ b/homeassistant/components/yardian/sensor.py
@@ -1,0 +1,162 @@
+"""Sensors for Yardian integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinator import YardianUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yardian sensors."""
+    coordinator: YardianUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[SensorEntity] = [
+        YardianRainDelaySensor(coordinator),
+        YardianActiveZoneCountSensor(coordinator),
+        YardianSensorDelaySensor(coordinator),
+        YardianWaterHammerDurationSensor(coordinator),
+        YardianRegionSensor(coordinator),
+    ]
+
+    async_add_entities(entities)
+
+
+class _BaseYardianSensor(CoordinatorEntity[YardianUpdateCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+
+
+class YardianRainDelaySensor(_BaseYardianSensor):
+    """Remaining rain delay in seconds."""
+
+    _attr_translation_key = "rain_delay"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the rain delay sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-rain-delay"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return remaining rain delay in seconds."""
+        val = self.coordinator.data.oper_info.get("iRainDelay")
+        if isinstance(val, int):
+            # Some devices report negative remaining time; clamp to 0
+            return max(0, val)
+        return None
+
+
+class YardianActiveZoneCountSensor(_BaseYardianSensor):
+    """Number of zones currently running."""
+
+    _attr_translation_key = "active_zone_count"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the active zone count sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-active-zone-count"
+
+    @property
+    def native_value(self) -> int:
+        """Return number of currently active zones."""
+        return len(self.coordinator.data.active_zones)
+
+
+class YardianSensorDelaySensor(_BaseYardianSensor):
+    """Sensor delay duration in seconds (diagnostic)."""
+
+    _attr_translation_key = "sensor_delay"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the sensor delay diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-sensor-delay"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return sensor delay in seconds.
+
+        Some firmware reports an absolute Unix timestamp for when the sensor
+        delay ends. If the value looks like a timestamp (far in the future),
+        convert to remaining seconds; otherwise treat it as a duration.
+        """
+        val = self.coordinator.data.oper_info.get("iSensorDelay")
+        if isinstance(val, int):
+            # Heuristic: values larger than ~1 year are treated as epoch seconds
+            if val > 365 * 24 * 3600:
+                now = int(dt_util.utcnow().timestamp())
+                return max(0, val - now)
+            # Otherwise, treat as seconds duration
+            return max(0, val)
+        return None
+
+
+class YardianWaterHammerDurationSensor(_BaseYardianSensor):
+    """Water hammer duration in seconds (diagnostic)."""
+
+    _attr_translation_key = "water_hammer_duration"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the water hammer duration diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-water-hammer-duration"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return water hammer protection duration in seconds."""
+        val = self.coordinator.data.oper_info.get("iWaterHammerDuration")
+        if isinstance(val, int):
+            return val
+        return None
+
+
+class YardianRegionSensor(_BaseYardianSensor):
+    """Region text (diagnostic)."""
+
+    _attr_translation_key = "region"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YardianUpdateCoordinator) -> None:
+        """Initialize the region diagnostic sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.yid}-region"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the controller region label."""
+        val = self.coordinator.data.oper_info.get("region")
+        if isinstance(val, str) and val:
+            return val
+        return None

--- a/homeassistant/components/yardian/strings.json
+++ b/homeassistant/components/yardian/strings.json
@@ -20,6 +20,39 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "entity": {
+    "binary_sensor": {
+      "watering_running": {
+        "name": "Watering running"
+      },
+      "standby": {
+        "name": "Standby"
+      },
+      "freeze_prevent": {
+        "name": "Freeze prevent"
+      },
+      "zone_enabled": {
+        "name": "Zone {zone} enabled"
+      }
+    },
+    "sensor": {
+      "rain_delay": {
+        "name": "Rain delay"
+      },
+      "active_zone_count": {
+        "name": "Active zone count"
+      },
+      "sensor_delay": {
+        "name": "Sensor delay"
+      },
+      "water_hammer_duration": {
+        "name": "Water hammer duration"
+      },
+      "region": {
+        "name": "Region"
+      }
+    }
+  },
   "services": {
     "start_irrigation": {
       "name": "Start irrigation",

--- a/tests/components/yardian/test_coordinator.py
+++ b/tests/components/yardian/test_coordinator.py
@@ -1,0 +1,78 @@
+"""Tests for the Yardian coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pyyardian import NotAuthorizedException
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.components.yardian.coordinator import (
+    YardianCombinedState,
+    YardianUpdateCoordinator,
+)
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_coordinator_combines_state(hass):
+    """Coordinator returns combined state from device and operation info."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.return_value = SimpleNamespace(
+        zones=[["Zone 1", 1]],
+        active_zones={0},
+    )
+    client.fetch_oper_info.return_value = {"iStandby": 1}
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    state = await coordinator._async_update_data()
+
+    assert isinstance(state, YardianCombinedState)
+    assert state.zones == [["Zone 1", 1]]
+    assert state.active_zones == {0}
+    assert state.oper_info["iStandby"] == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_raises_auth_failed(hass):
+    """Coordinator raises ConfigEntryAuthFailed on invalid auth."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "token",
+            "yid": "yardian-1",
+            "model": "PRO",
+        },
+        title="Yardian",
+        unique_id="yardian-1",
+    )
+    entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.fetch_device_state.side_effect = NotAuthorizedException
+
+    coordinator = YardianUpdateCoordinator(hass, entry, client)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()

--- a/tests/components/yardian/test_coordinator.py
+++ b/tests/components/yardian/test_coordinator.py
@@ -1,7 +1,5 @@
 """Tests for the Yardian coordinator."""
 
-from __future__ import annotations
-
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -13,13 +11,14 @@ from homeassistant.components.yardian.coordinator import (
     YardianCombinedState,
     YardianUpdateCoordinator,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio
-async def test_coordinator_combines_state(hass):
+async def test_coordinator_combines_state(hass: HomeAssistant) -> None:
     """Coordinator returns combined state from device and operation info."""
 
     entry = MockConfigEntry(
@@ -53,7 +52,7 @@ async def test_coordinator_combines_state(hass):
 
 
 @pytest.mark.asyncio
-async def test_coordinator_raises_auth_failed(hass):
+async def test_coordinator_raises_auth_failed(hass: HomeAssistant) -> None:
     """Coordinator raises ConfigEntryAuthFailed on invalid auth."""
 
     entry = MockConfigEntry(

--- a/tests/components/yardian/test_platforms.py
+++ b/tests/components/yardian/test_platforms.py
@@ -1,0 +1,372 @@
+"""Test Yardian entities setup and behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pyyardian.async_client import YardianDeviceState
+
+from homeassistant.components.yardian.const import DOMAIN
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+class FakeYardianClient:
+    """Fake AsyncYardianClient for tests."""
+
+    def __init__(self, *_: object, **__: object) -> None:
+        """Initialize fake client with mocked stop_irrigation."""
+        self.stop_irrigation = AsyncMock()
+        self.start_irrigation = AsyncMock()
+
+    async def fetch_device_state(self):  # pyyardian.YardianDeviceState-like
+        """Return fake YardianDeviceState with three zones and one active."""
+        zones = [["Zone 1", 1], ["Zone 2", 0], ["Zone 3", 1]]
+        active_zones = {0}
+        return YardianDeviceState(zones=zones, active_zones=active_zones)
+
+    async def fetch_oper_info(self):
+        """Return fake operation info."""
+        return {
+            "iRainDelay": 3600,
+            "iStandby": 0,
+            "fFreezePrevent": 1,
+            "iSensorDelay": 5,
+            "iWaterHammerDuration": 2,
+            "region": "US",
+        }
+
+
+@pytest.mark.asyncio
+async def test_entities_setup(hass: HomeAssistant) -> None:
+    """Test entities are created (no stop button) and zone switches respect defaults."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Binary sensor: watering running
+    bs_entity_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "yid123-watering-running"
+    )
+    assert bs_entity_id is not None
+    bs = hass.states.get(bs_entity_id)
+    assert bs.state == "on"
+    assert bs.attributes.get("device_class") == "running"
+
+    # Sensor: rain delay
+    rain_entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-rain-delay")
+    assert rain_entity_id is not None
+    rain = hass.states.get(rain_entity_id)
+    assert rain.state == "3600"
+    assert rain.attributes.get("device_class") == "duration"
+    assert rain.attributes.get("unit_of_measurement") == "s"
+    assert rain.attributes.get("state_class") == "measurement"
+
+    # Sensor: active zone count
+    azc_entity_id = ent_reg.async_get_entity_id(
+        "sensor", DOMAIN, "yid123-active-zone-count"
+    )
+    assert azc_entity_id is not None
+    azc = hass.states.get(azc_entity_id)
+    assert azc.state == "1"
+    assert azc.attributes.get("state_class") == "measurement"
+
+    # Ensure no stop button is created
+    assert ent_reg.async_get_entity_id("button", DOMAIN, "yid123-stop") is None
+
+    # Device info includes serial number
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, "yid123")})
+    assert device is not None
+    assert device.serial_number == "SN1"
+
+
+@pytest.mark.asyncio
+async def test_binary_sensors_state(hass: HomeAssistant) -> None:
+    """Test standby and freeze_prevent binary sensors reflect oper_info."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    standby_id = ent_reg.async_get_entity_id("binary_sensor", DOMAIN, "yid123-standby")
+    freeze_id = ent_reg.async_get_entity_id(
+        "binary_sensor", DOMAIN, "yid123-freeze-prevent"
+    )
+    assert standby_id and freeze_id
+    assert hass.states.get(standby_id).state == "off"
+    assert hass.states.get(freeze_id).state == "on"
+    standby_entry = ent_reg.async_get(standby_id)
+    freeze_entry = ent_reg.async_get(freeze_id)
+    assert standby_entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert freeze_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+
+@pytest.mark.asyncio
+async def test_enable_diagnostic_sensors_values(hass: HomeAssistant) -> None:
+    """Enable diagnostic sensors and assert values and units."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Enable diagnostic sensors
+    for uid in ("yid123-sensor-delay", "yid123-water-hammer-duration", "yid123-region"):
+        eid = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+        ent_reg.async_update_entity(eid, disabled_by=None)
+
+    # Reload entry to apply registry changes (patch client again during reload)
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Assert values and attributes
+    sensor_delay = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-sensor-delay")
+    )
+    water_hammer = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-water-hammer-duration")
+    )
+    region = hass.states.get(
+        ent_reg.async_get_entity_id("sensor", DOMAIN, "yid123-region")
+    )
+
+    assert sensor_delay.state == "5"
+    assert sensor_delay.attributes.get("device_class") == "duration"
+    assert sensor_delay.attributes.get("unit_of_measurement") == "s"
+    # state_class may not be exposed as attribute in newer core versions
+
+    assert water_hammer.state == "2"
+    assert water_hammer.attributes.get("device_class") == "duration"
+    assert water_hammer.attributes.get("unit_of_measurement") == "s"
+
+    assert region.state == "US"
+
+
+@pytest.mark.asyncio
+async def test_enable_zone_enabled_entity_and_state(hass: HomeAssistant) -> None:
+    """Enable a per-zone enabled binary sensor and check its state."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    eid = ent_reg.async_get_entity_id("binary_sensor", DOMAIN, "yid123-zone-enabled-0")
+    ent_reg.async_update_entity(eid, disabled_by=None)
+
+    with (
+        patch(
+            "homeassistant.components.yardian.AsyncYardianClient",
+            return_value=FakeYardianClient(),
+        ),
+        patch(
+            "homeassistant.requirements.RequirementsManager.async_process_requirements",
+            return_value=None,
+        ),
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(eid)
+    assert state is not None and state.state == "on"
+
+
+@pytest.mark.asyncio
+async def test_no_stop_button_present(hass: HomeAssistant) -> None:
+    """Verify stop-all button is no longer created."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get_entity_id("button", DOMAIN, "yid123-stop") is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_entities(hass: HomeAssistant) -> None:
+    """Verify diagnostic entities are disabled by default in the registry."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.2.3.4",
+            "access_token": "abc",
+            "name": "Yardian",
+            "yid": "yid123",
+            "model": "PRO1902",
+            "serialNumber": "SN1",
+        },
+        title="Yardian Smart Sprinkler",
+        unique_id="yid123",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yardian.AsyncYardianClient",
+        return_value=FakeYardianClient(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+
+    # Per-zone enabled sensors (for 3 zones created in FakeYardianClient)
+    for idx in range(3):
+        eid = ent_reg.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"yid123-zone-enabled-{idx}"
+        )
+        assert eid is not None
+        reg_entry = ent_reg.async_get(eid)
+    assert reg_entry is not None and reg_entry.disabled
+    assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert reg_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+    # Diagnostic sensors disabled by default
+    for dom, uid in (
+        ("sensor", "yid123-sensor-delay"),
+        ("sensor", "yid123-water-hammer-duration"),
+        ("sensor", "yid123-region"),
+    ):
+        eid = ent_reg.async_get_entity_id(dom, DOMAIN, uid)
+        assert eid is not None
+        reg_entry = ent_reg.async_get(eid)
+        assert reg_entry is not None and reg_entry.disabled
+        assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        assert reg_entry.entity_category is EntityCategory.DIAGNOSTIC
+


### PR DESCRIPTION
## Summary
- ensure zone switches only enable by default when the controller reports enabled
- keep the start_irrigation entity service forwarding minutes intact with regression coverage
- assert the service registration to guard against accidental removal

## Notes
- builds on #20